### PR TITLE
Bump sonar-java to 5.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,14 @@ task infra(dependsOn: ["copyLibs", "copyTestLibs", "jar"])
 test.dependsOn(copyPlugins)
 
 dependencies {
-    compile("org.sonarsource.sonarlint.core:sonarlint-core:2.17.0.899")
-    compile("org.sonarsource.sonarlint.core:sonarlint-client-api:2.17.0.899")
+    compile("org.sonarsource.sonarlint.core:sonarlint-core:3.0.1.1181")
+    compile("org.sonarsource.sonarlint.core:sonarlint-client-api:3.0.1.1181")
+
     compile("org.sonarsource.sonarlint:sonarlint-cli:2.1.0.566")
     compile("com.google.code.gson:gson:2.8.2")
 
     // Plugins
-    testCompile("org.sonarsource.java:sonar-java-plugin:4.14.0.11784")
+    testCompile("org.sonarsource.java:sonar-java-plugin:5.14.0.18788")
 
     testCompile("org.assertj:assertj-core:2.8.0")
     testCompile("org.skyscreamer:jsonassert:1.5.0")


### PR DESCRIPTION
In order to upgrade the `sonar-java` plugin there are some dependencies that need to be updated as well. 
 - `sonarlint-core` to version `3.0.1.1181`
 - `sonarlint-client-api` to version `3.0.1.1181`

The version  [5.14.0.18788](https://mvnrepository.com/artifact/org.sonarsource.java/sonar-java-plugin/5.14.0.18788) of `sonar-java` supports analysis over _**Java 11**_ projects.

Jira [ticket](https://codeclimate.atlassian.net/browse/QUA-44?atlOrigin=eyJpIjoiNmNmMGEzMTRlOWRhNDg3YjgxY2Y0OWUyNDM0NGNjMTIiLCJwIjoiaiJ9)
