### PR TITLE
Bump sonar-java 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     compile("com.google.code.gson:gson:2.8.2")
 
     // Plugins
-    testCompile("org.sonarsource.java:sonar-java-plugin:5.14.0.18788")
+    testCompile("org.sonarsource.java:sonar-java-plugin:6.0.0.20538")
 
     testCompile("org.assertj:assertj-core:2.8.0")
     testCompile("org.skyscreamer:jsonassert:1.5.0")

--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,14 @@ task infra(dependsOn: ["copyLibs", "copyTestLibs", "jar"])
 test.dependsOn(copyPlugins)
 
 dependencies {
-    compile("org.sonarsource.sonarlint.core:sonarlint-core:2.17.0.899")
-    compile("org.sonarsource.sonarlint.core:sonarlint-client-api:2.17.0.899")
+    compile("org.sonarsource.sonarlint.core:sonarlint-core:3.0.1.1181")
+    compile("org.sonarsource.sonarlint.core:sonarlint-client-api:3.0.1.1181")
+
     compile("org.sonarsource.sonarlint:sonarlint-cli:2.1.0.566")
     compile("com.google.code.gson:gson:2.8.2")
 
     // Plugins
-    testCompile("org.sonarsource.java:sonar-java-plugin:4.14.0.11784")
+    testCompile("org.sonarsource.java:sonar-java-plugin:5.14.0.18788")
 
     testCompile("org.assertj:assertj-core:2.8.0")
     testCompile("org.skyscreamer:jsonassert:1.5.0")


### PR DESCRIPTION
The upgrade to of the `sonar-java` plugin to version [6.0.0.20538](https://mvnrepository.com/artifact/org.sonarsource.java/sonar-java-plugin/6.0.0.20538) demands certain modifications. 

Below there is an example of one of those tests that fail when upgrading sonar-java, 90% of the failed tests, failed with the same error `Unable to find rule with key squid:S1602`

<img width="620" alt="Screen Shot 2020-05-13 at 10 08 30 PM" src="https://user-images.githubusercontent.com/11605222/81941728-95aaf780-95cf-11ea-9744-ff71119e1000.png">

I have tried updating the `sonarlint-cli`, sonarlint-client-api` and the `sonarlint-core` to check if could be a solution to solve the `squid` error, but it wasn't the case.

Looking for explanation I found several links related to this issue, seems like somebody else has also suffered it

 - https://jira.sonarsource.com/browse/SONARJAVA-3277
 - https://jira.sonarsource.com/browse/SONAR-13019
 - https://jira.sonarsource.com/browse/SONARJAVA-3160
 - https://jira.sonarsource.com/browse/SONAR-12736


Looking at the `sonar-java` repo comparing releases `5.14.0.18788...6.0.2.20657` we can see the change that makes our tests fail
![Screen Shot 2020-05-14 at 11 09 35 AM](https://user-images.githubusercontent.com/11605222/81944641-6dbd9300-95d3-11ea-8e82-35681eb9cbf6.png)

- Sonar-Java releases comparison [5.14.0.18788...6.0.2.20657](https://github.com/SonarSource/sonar-java/compare/5.14.0.18788...6.0.2.20657)
- Specific [PR](https://github.com/SonarSource/sonar-java/pull/2729/commits) that introduced the changes
